### PR TITLE
新規ユーザー登録機能実装

### DIFF
--- a/src/laravel_project/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/laravel_project/app/Http/Controllers/Auth/RegisterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use App\User;
+use App\Rules\PasswordValidation;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -50,9 +51,9 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:20'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => ['required', 'string', new PasswordValidation, 'confirmed'],
         ]);
     }
 

--- a/src/laravel_project/app/User.php
+++ b/src/laravel_project/app/User.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use Notifiable;
 

--- a/src/laravel_project/resources/lang/ja.json
+++ b/src/laravel_project/resources/lang/ja.json
@@ -4,7 +4,7 @@
     "Forgot Your Password?": "パスワードを忘れた場合",
     "Reset Password": "パスワード再設定",
     "Send Password Reset Link": "パスワード再設定URLを送信",
-    "Name": "お名前",
+    "Name": "ユーザー名",
     "E-Mail Address": "メールアドレス",
     "Password": "パスワード",
     "Confirm Password": "パスワード(確認用)",

--- a/src/laravel_project/resources/lang/ja.json
+++ b/src/laravel_project/resources/lang/ja.json
@@ -15,5 +15,13 @@
     "This password reset link will expire in :count minutes.": "再設定URLの有効期限は :count 分です。",
     "If you did not request a password reset, no further action is required.": "もしパスワード再発行をリクエストしていない場合、操作は不要です。",
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\"ボタンを押しても何も起きない場合、以下URLをコピーしてWebブラウザに貼り付けてください。",
-    "Regards": "よろしくお願いいたします"
+    "Regards": "よろしくお願いいたします",
+    "Verify Your Email Address": "メールアドレス認証",
+    "A fresh verification link has been sent to your email address.": "新しい認証用URLを送信しました。",
+    "Before proceeding, please check your email for a verification link.": "登録処理を進めるために、送信されたメールからアドレス認証を行ってください。",
+    "If you did not receive the email": "もしメールが届かない場合は新しいメールを送信しますので",
+    "click here to request another": "こちらをクリックしてください。",
+    "Verify Email Address": "メールアドレス認証",
+    "Please click the button below to verify your email address.": "下記のボタンをクリックして、メールアドレス認証を行ってください。",
+    "If you did not create an account, no further action is required.": "もし新規アカウント登録を申請していない場合、操作は不要です。"
 }

--- a/src/laravel_project/resources/lang/ja.json
+++ b/src/laravel_project/resources/lang/ja.json
@@ -23,5 +23,5 @@
     "click here to request another": "こちらをクリックしてください。",
     "Verify Email Address": "メールアドレス認証",
     "Please click the button below to verify your email address.": "下記のボタンをクリックして、メールアドレス認証を行ってください。",
-    "If you did not create an account, no further action is required.": "もし新規アカウント登録を申請していない場合、操作は不要です。"
+    "If you did not create an account, no further action is required.": "もし新規登録申請をしていない場合、お手数ですが管理者までご連絡ください。"
 }

--- a/src/laravel_project/resources/lang/ja/validation.php
+++ b/src/laravel_project/resources/lang/ja/validation.php
@@ -112,7 +112,7 @@ return [
     'starts_with' => ':attributeを:valuesから始まるよう入力してください。',
     'string' => ':attributeは門司で入力してください。',
     'timezone' => ':attributeを正しいタイムゾーンで入力してください。',
-    'unique' => ':attributeは既に取得されているため、違うものを入力してください。',
+    'unique' => ':attributeは既に使用されているため、違うものを入力してください。',
     'uploaded' => ':attributeはアップロードに失敗しました。',
     'url' => ':attributeを正しいURLで入力してください。',
     'uuid' => ':attributeを正しいUUIDで入力してください。',

--- a/src/laravel_project/resources/lang/ja/validation.php
+++ b/src/laravel_project/resources/lang/ja/validation.php
@@ -79,7 +79,7 @@ return [
     'max' => [
         'numeric' => ':attributeは:max以下で入力してください。',
         'file' => ':attributeは:max KB以下のファイルを選択してください。',
-        'string' => ':attributeは:max文字以下入力してください。',
+        'string' => ':attributeは:max文字以下で入力してください。',
         'array' => ':attributeは:max個以下にしてください。',
     ],
     'mimes' => ':attributeは:values形式で選択してください。',
@@ -147,6 +147,7 @@ return [
     */
 
     'attributes' => [
+        'name' => 'ユーザー名',
         'email' => 'メールアドレス',
         'password' => 'パスワード',
     ],

--- a/src/laravel_project/routes/web.php
+++ b/src/laravel_project/routes/web.php
@@ -15,6 +15,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Auth::routes();
+// ユーザー認証系（メール認証機能を有効）
+Auth::routes(['verify' => true]);
 
-Route::get('/home', 'HomeController@index')->name('home');
+Route::get('/home', 'HomeController@index')->name('home')->middleware('verified');


### PR DESCRIPTION
## 概要
新規ユーザー登録機能を実装。

## 変更内容
- 画面表示の日本語化
- メール認証機能
- バリデーション修正（ユーザー名:20文字以下、パスワード8文字以上半角英数字最低1文字）

## 問題点・バグなど
- メールアドレス認証に失敗したアドレスで再度登録しようとした場合、使用済みのため登録できない
⇒ 登録自体は完了しているので、ログイン画面からパスワード再設定メールを発行し、ログインできる。そもそも、登録操作を行っていないのに認証メールが届いた場合は、受信者から管理者へ連絡してもらい、管理者側で該当メールアドレスのデータを削除するのが正しい運用方法か？調査必要。